### PR TITLE
Provide as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the package.
 npm install --save elasticsearch-scrolltoend
 ```
 
-Then extend the Elasticsearch API.
+Then extend the Elasticsearch API by including this plugin.
 
 ```js
 'use strict';
@@ -20,9 +20,12 @@ Then extend the Elasticsearch API.
 const hosts = ['127.0.0.1'];
 const apiVersion = '2.x';
 const elasticsearch = require('elasticsearch');
-elasticsearch.Client.apis[apiVersion].scrollToEnd = require('elasticsearch-scrolltoend');
+const esScrollToEnd = require('elasticsearch-scrolltoend');
 
-const client = new elasticsearch.Client({hosts, apiVersion});
+const client = new elasticsearch.Client({
+  hosts, apiVersion,
+  plugins: [ esScrollToEnd.plugin ]
+});
 ```
 
 ## Example

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(scroll, handler) {
+function scrollToEnd(scroll, handler) {
   let self = this;
   let total = 0;
   let batches = 0;
@@ -33,3 +33,10 @@ module.exports = function(scroll, handler) {
     });
   }
 };
+
+function esPlugin(Client, config, components) {
+  Client.prototype.scrollToEnd = scrollToEnd;
+}
+
+module.exports = scrollToEnd;
+module.exports.plugin = esPlugin;


### PR DESCRIPTION
Along with custom classes for specific portions of the Client users can also just define arbitrary plugins which act like decorators: they are passed the `Client` class and `config` before it's instantiated and can modify it or replace it (by returning a new class).

This pr adds a `.plugin` property to the `elasticsearch-scrolltoend` module, as to not break backwards compatibility, though it could be argued this should be the default interface.

I have also update the readme to show the changes to initialization.
