### PR TITLE
add babel transpilation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 .DS_Store
 node_modules
-index.es5.js
+index.js

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "elasticsearch-scrolltoend",
   "version": "0.0.4",
   "description": "Elasticsearch-js client extension for processing scroll results.",
-  "main": "index.js",
+  "main": "index.es5.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "babel --modules=umd -o index.es5.js index.js",
+    "dev": "npm run build -- --watch",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds a few npm tasks for babel transpilation and publishes and causes an es5 version to be published to npm.

tasks:
- `npm run build`: build once
- `npm run dev`: watch the source and recompile
